### PR TITLE
Fix protocol version parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Max Hawkins](https://github.com/maxhawkins)
 * [mchlrhw](https://github.com/mchlrhw)
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Guilherme Souza](https://github.com/gqgs)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -431,7 +431,7 @@ func unmarshalProtocolVersion(l *lexer) (stateFn, error) {
 
 	version, err := strconv.ParseInt(value, 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("sdp: invalid numeric value `%v`", version)
+		return nil, fmt.Errorf("sdp: invalid numeric value `%v`", value)
 	}
 
 	// As off the latest draft of the rfc this value is required to be 0.


### PR DESCRIPTION
#### Description

On error, the failed parsed result was being returned instead of the parsing input
