### PR TITLE
Permit out-of-order media description fields when parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Guilherme Souza](https://github.com/gqgs)
 * [adwpc](https://github.com/adwpc) - *extmap add transport-cc*
 * [Atsushi Watanabe](https://github.com/at-wat)
+* [Luke S](https://github.com/encounter)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -367,6 +367,18 @@ func s14(l *lexer) (stateFn, error) {
 	switch key {
 	case "a=":
 		return unmarshalMediaAttribute, nil
+	case "k=":
+		// Non-spec ordering
+		return unmarshalMediaEncryptionKey, nil
+	case "b=":
+		// Non-spec ordering
+		return unmarshalMediaBandwidth, nil
+	case "c=":
+		// Non-spec ordering
+		return unmarshalMediaConnectionInformation, nil
+	case "i=":
+		// Non-spec ordering
+		return unmarshalMediaTitle, nil
 	case "m=":
 		return unmarshalMediaDescription, nil
 	}
@@ -390,6 +402,11 @@ func s15(l *lexer) (stateFn, error) {
 		return unmarshalMediaEncryptionKey, nil
 	case "b=":
 		return unmarshalMediaBandwidth, nil
+	case "c=":
+		return unmarshalMediaConnectionInformation, nil
+	case "i=":
+		// Non-spec ordering
+		return unmarshalMediaTitle, nil
 	case "m=":
 		return unmarshalMediaDescription, nil
 	}
@@ -415,6 +432,9 @@ func s16(l *lexer) (stateFn, error) {
 		return unmarshalMediaConnectionInformation, nil
 	case "b=":
 		return unmarshalMediaBandwidth, nil
+	case "i=":
+		// Non-spec ordering
+		return unmarshalMediaTitle, nil
 	case "m=":
 		return unmarshalMediaDescription, nil
 	}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -72,6 +72,18 @@ const (
 	MediaConnectionInformationSDP = MediaNameSDP +
 		"c=IN IP4 203.0.113.1\r\n"
 
+	MediaDescriptionOutOfOrderSDP = MediaNameSDP +
+		"a=rtpmap:99 h263-1998/90000\r\n" +
+		"a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host\r\n" +
+		"c=IN IP4 203.0.113.1\r\n" +
+		"i=Vivamus a posuere nisl\r\n"
+
+	MediaDescriptionOutOfOrderSDPActual = MediaNameSDP +
+		"i=Vivamus a posuere nisl\r\n" +
+		"c=IN IP4 203.0.113.1\r\n" +
+		"a=rtpmap:99 h263-1998/90000\r\n" +
+		"a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host\r\n"
+
 	MediaBandwidthSDP = MediaNameSDP +
 		"b=X-YZ:128\r\n" +
 		"b=AS:12345\r\n"
@@ -112,8 +124,9 @@ const (
 
 func TestRoundTrip(t *testing.T) {
 	for _, test := range []struct {
-		Name string
-		SDP  string
+		Name   string
+		SDP    string
+		Actual string
 	}{
 		{
 			Name: "SessionInformation",
@@ -125,7 +138,7 @@ func TestRoundTrip(t *testing.T) {
 		},
 		{
 			Name: "EmailAddress",
-			SDP:  string(EmailAddressSDP),
+			SDP:  EmailAddressSDP,
 		},
 		{
 			Name: "PhoneNumber",
@@ -164,8 +177,9 @@ func TestRoundTrip(t *testing.T) {
 			SDP:  MediaConnectionInformationSDP,
 		},
 		{
-			Name: "MediaConnectionInformation",
-			SDP:  MediaConnectionInformationSDP,
+			Name:   "MediaDescriptionOutOfOrder",
+			SDP:    MediaDescriptionOutOfOrderSDP,
+			Actual: MediaDescriptionOutOfOrderSDPActual,
 		},
 		{
 			Name: "MediaBandwidth",
@@ -195,7 +209,11 @@ func TestRoundTrip(t *testing.T) {
 		if got, want := err, error(nil); got != want {
 			t.Fatalf("Marshal(): err=%v, want %v", got, want)
 		}
-		if got, want := string(actual), test.SDP; got != want {
+		want := test.SDP
+		if test.Actual != "" {
+			want = test.Actual
+		}
+		if got := string(actual); got != want {
 			t.Fatalf("Marshal(%s) = %q, want %q", test.Name, got, want)
 		}
 	}


### PR DESCRIPTION
RFC [1] defines a strict order for media description fields,
however some implementations do not honor this when producing
SDP. We can safely parse these fields out of order, and verify
that our implementation produces the correct order when testing
marshalling.

[1] https://tools.ietf.org/html/rfc4566#section-9
