### PR TITLE
Parse rtcp-fb attributes into codec info from SDP

### DIFF
--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -93,7 +93,10 @@ const (
 
 	MediaAttributesSDP = MediaNameSDP +
 		"a=rtpmap:99 h263-1998/90000\r\n" +
-		"a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host\r\n"
+		"a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host\r\n" +
+		"a=rtcp-fb:97 ccm fir\r\n" +
+		"a=rtcp-fb:97 nack\r\n" +
+		"a=rtcp-fb:97 nack pli\r\n"
 
 	CanonicalUnmarshalSDP = "v=0\r\n" +
 		"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package sdp
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -25,6 +26,9 @@ func getTestSessionDescription() SessionDescription {
 					NewAttribute("rtpmap:121 VP9/90000", ""),
 					NewAttribute("rtpmap:126 H264/90000", ""),
 					NewAttribute("rtpmap:97 H264/90000", ""),
+					NewAttribute("rtcp-fb:97 ccm fir", ""),
+					NewAttribute("rtcp-fb:97 nack", ""),
+					NewAttribute("rtcp-fb:97 nack pli", ""),
 				},
 			},
 		},
@@ -118,10 +122,11 @@ func TestGetCodecForPayloadType(t *testing.T) {
 		{
 			PayloadType: 97,
 			Expected: Codec{
-				PayloadType: 97,
-				Name:        "H264",
-				ClockRate:   90000,
-				Fmtp:        "profile-level-id=42e01f;level-asymmetry-allowed=1",
+				PayloadType:  97,
+				Name:         "H264",
+				ClockRate:    90000,
+				Fmtp:         "profile-level-id=42e01f;level-asymmetry-allowed=1",
+				RTCPFeedback: []string{"ccm fir", "nack", "nack pli"},
 			},
 		},
 	} {
@@ -132,7 +137,7 @@ func TestGetCodecForPayloadType(t *testing.T) {
 			t.Fatalf("GetCodecForPayloadType(): err=%v, want=%v", got, want)
 		}
 
-		if actual != test.Expected {
+		if !reflect.DeepEqual(actual, test.Expected) {
 			t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", test.Expected, actual)
 		}
 	}


### PR DESCRIPTION
Currently, rtcp-fb attributes are ignored in codec parsing.
Since the RTCPFeedback struct is located in webrtc, this parses the attributes
into simple strings that can be later split into type/parameter.
