### PR TITLE
Relax record terminate char spec

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -55,7 +55,11 @@ import (
 // In order to generate the following state table and draw subsequent
 // deterministic finite-state automota ("DFA") the following regex was used to
 // derive the DFA:
-// 		vosi?u?e?p?c?b*(tr*)+z?k?a*(mi?c?b*k?a*)*
+//    vosi?u?e?p?c?b*(tr*)+z?k?a*(mi?c?b*k?a*)*
+// possible place and state to exit:
+//                    **   * * *  ** * * * *
+//                    99   1 1 1  11 1 1 1 1
+//                         3 1 1  26 5 5 4 4
 //
 // Please pay close attention to the `k`, and `a` parsing states. In the table
 // below in order to distinguish between the states belonging to the media

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,6 +1,7 @@
 package sdp
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -12,6 +13,33 @@ const (
 	SessionInformationSDP = BaseSDP +
 		"i=A Seminar on the session description protocol\r\n" +
 		"t=3034423619 3042462419\r\n"
+
+	// https://tools.ietf.org/html/rfc4566#section-5
+	// Parsers SHOULD be tolerant and also accept records terminated
+	// with a single newline character.
+	SessionInformationSDPLFOnly = "v=0\n" +
+		"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\n" +
+		"s=SDP Seminar\n" +
+		"i=A Seminar on the session description protocol\n" +
+		"t=3034423619 3042462419\n"
+
+	// SessionInformationSDPCROnly = "v=0\r" +
+	// 	"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r" +
+	// 	"s=SDP Seminar\r"
+	// 	"i=A Seminar on the session description protocol\r" +
+	// 	"t=3034423619 3042462419\r"
+
+	// Other SDP parsers (e.g. one in VLC media player) allow
+	// empty lines.
+	SessionInformationSDPExtraCRLF = "v=0\r\n" +
+		"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +
+		"\r\n" +
+		"s=SDP Seminar\r\n" +
+		"\r\n" +
+		"i=A Seminar on the session description protocol\r\n" +
+		"\r\n" +
+		"t=3034423619 3042462419\r\n" +
+		"\r\n"
 
 	URISDP = BaseSDP +
 		"u=http://www.example.com/seminars/sdp.pdf\r\n" +
@@ -48,6 +76,9 @@ const (
 		"r=604800 3600 0 90000\r\n" +
 		"r=259200 7200 0 75600\r\n"
 
+	RepeatTimesSDPExtraCRLF = RepeatTimesSDPExpected +
+		"\r\n"
+
 	// The expected value looks a bit different for the same reason as mentioned
 	// above regarding RepeatTimes.
 	TimeZonesSDP = TimingSDP +
@@ -56,8 +87,17 @@ const (
 	TimeZonesSDPExpected = TimingSDP +
 		"r=2882844526 -3600 2898848070 0\r\n"
 
+	TimeZonesSDP2 = TimingSDP +
+		"z=2882844526 -3600 2898848070 0\r\n"
+
+	TimeZonesSDP2ExtraCRLF = TimeZonesSDP2 +
+		"\r\n"
+
 	SessionEncryptionKeySDP = TimingSDP +
 		"k=prompt\r\n"
+
+	SessionEncryptionKeySDPExtraCRLF = SessionEncryptionKeySDP +
+		"\r\n"
 
 	SessionAttributesSDP = TimingSDP +
 		"a=rtpmap:96 opus/48000\r\n"
@@ -66,11 +106,17 @@ const (
 		"m=video 51372 RTP/AVP 99\r\n" +
 		"m=audio 54400 RTP/SAVPF 0 96\r\n"
 
+	MediaNameSDPExtraCRLF = MediaNameSDP +
+		"\r\n"
+
 	MediaTitleSDP = MediaNameSDP +
 		"i=Vivamus a posuere nisl\r\n"
 
 	MediaConnectionInformationSDP = MediaNameSDP +
 		"c=IN IP4 203.0.113.1\r\n"
+
+	MediaConnectionInformationSDPExtraCRLF = MediaConnectionInformationSDP +
+		"\r\n"
 
 	MediaDescriptionOutOfOrderSDP = MediaNameSDP +
 		"a=rtpmap:99 h263-1998/90000\r\n" +
@@ -90,6 +136,9 @@ const (
 
 	MediaEncryptionKeySDP = MediaNameSDP +
 		"k=prompt\r\n"
+
+	MediaEncryptionKeySDPExtraCRLF = MediaEncryptionKeySDP +
+		"\r\n"
 
 	MediaAttributesSDP = MediaNameSDP +
 		"a=rtpmap:99 h263-1998/90000\r\n" +
@@ -132,6 +181,21 @@ func TestRoundTrip(t *testing.T) {
 		Actual string
 	}{
 		{
+			Name:   "SessionInformationSDPLFOnly",
+			SDP:    SessionInformationSDPLFOnly,
+			Actual: SessionInformationSDP,
+		},
+		// {
+		// 	Name:   "SessionInformationSDPCROnly",
+		// 	SDP:    SessionInformationSDPCROnly,
+		// 	Actual: SessionInformationSDPBaseSDP,
+		// },
+		{
+			Name:   "SessionInformationSDPExtraCRLF",
+			SDP:    SessionInformationSDPExtraCRLF,
+			Actual: SessionInformationSDP,
+		},
+		{
 			Name: "SessionInformation",
 			SDP:  SessionInformationSDP,
 		},
@@ -148,8 +212,9 @@ func TestRoundTrip(t *testing.T) {
 			SDP:  PhoneNumberSDP,
 		},
 		{
-			Name: "SessionConnectionInformation",
-			SDP:  SessionConnectionInformationSDP,
+			Name:   "RepeatTimesSDPExtraCRLF",
+			SDP:    RepeatTimesSDPExtraCRLF,
+			Actual: RepeatTimesSDPExpected,
 		},
 		{
 			Name: "SessionConnectionInformation",
@@ -164,12 +229,27 @@ func TestRoundTrip(t *testing.T) {
 			SDP:  SessionEncryptionKeySDP,
 		},
 		{
+			Name:   "SessionEncryptionKeyExtraCRLF",
+			SDP:    SessionEncryptionKeySDPExtraCRLF,
+			Actual: SessionEncryptionKeySDP,
+		},
+		{
 			Name: "SessionAttributes",
 			SDP:  SessionAttributesSDP,
 		},
 		{
+			Name:   "TimeZonesSDP2ExtraCRLF",
+			SDP:    TimeZonesSDP2ExtraCRLF,
+			Actual: TimeZonesSDP2,
+		},
+		{
 			Name: "MediaName",
 			SDP:  MediaNameSDP,
+		},
+		{
+			Name:   "MediaNameExtraCRLF",
+			SDP:    MediaNameSDPExtraCRLF,
+			Actual: MediaNameSDP,
 		},
 		{
 			Name: "MediaTitle",
@@ -178,6 +258,11 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name: "MediaConnectionInformation",
 			SDP:  MediaConnectionInformationSDP,
+		},
+		{
+			Name:   "MediaConnectionInformationExtraCRLF",
+			SDP:    MediaConnectionInformationSDPExtraCRLF,
+			Actual: MediaConnectionInformationSDP,
 		},
 		{
 			Name:   "MediaDescriptionOutOfOrder",
@@ -193,6 +278,11 @@ func TestRoundTrip(t *testing.T) {
 			SDP:  MediaEncryptionKeySDP,
 		},
 		{
+			Name:   "MediaEncryptionKeyExtraCRLF",
+			SDP:    MediaEncryptionKeySDPExtraCRLF,
+			Actual: MediaEncryptionKeySDP,
+		},
+		{
 			Name: "MediaAttributes",
 			SDP:  MediaAttributesSDP,
 		},
@@ -201,24 +291,29 @@ func TestRoundTrip(t *testing.T) {
 			SDP:  CanonicalUnmarshalSDP,
 		},
 	} {
-		sd := &SessionDescription{}
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			sd := &SessionDescription{}
 
-		err := sd.Unmarshal([]byte(test.SDP))
-		if got, want := err, error(nil); got != want {
-			t.Fatalf("Unmarshal(%s): err=%v, want %v", test.Name, got, want)
-		}
+			err := sd.Unmarshal([]byte(test.SDP))
+			if got, want := err, error(nil); got != want {
+				t.Fatalf("Unmarshal:\nerr=%v\nwant=%v", got, want)
+			}
 
-		actual, err := sd.Marshal()
-		if got, want := err, error(nil); got != want {
-			t.Fatalf("Marshal(): err=%v, want %v", got, want)
-		}
-		want := test.SDP
-		if test.Actual != "" {
-			want = test.Actual
-		}
-		if got := string(actual); got != want {
-			t.Fatalf("Marshal(%s) = %q, want %q", test.Name, got, want)
-		}
+			actual, err := sd.Marshal()
+			if got, want := err, error(nil); got != want {
+				t.Fatalf("Marshal:\nerr=%v\nwant=%v", got, want)
+			}
+			want := test.SDP
+			if test.Actual != "" {
+				want = test.Actual
+			}
+			if got := string(actual); got != want {
+				t.Fatalf("Marshal:\ngot=%s\nwant=%s",
+					strconv.Quote(got), strconv.Quote(want),
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Allow single '\n' as a record termination since RFC 4566 says:
> parsers SHOULD be tolerant and also accept records terminated with
> a single newline character.

Allow to have empty lines.
Other SDP parsers (e.g. one in VLC media player) allow empty lines.


#### Reference issue
Fixes #44 