### PR TITLE
Add AttrKeyMsid

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [adwpc](https://github.com/adwpc) - *extmap add transport-cc*
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Luke S](https://github.com/encounter)
+* [Jerko Steiner](https://github.com/jeremija)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/jsep.go
+++ b/jsep.go
@@ -13,6 +13,7 @@ const (
 	AttrKeyGroup           = "group"
 	AttrKeySSRC            = "ssrc"
 	AttrKeySSRCGroup       = "ssrc-group"
+	AttrKeyMsid            = "msid"
 	AttrKeyMsidSemantic    = "msid-semantic"
 	AttrKeyConnectionSetup = "setup"
 	AttrKeyMID             = "mid"


### PR DESCRIPTION
Related to https://github.com/pion/webrtc/pull/1135

#### Description
Adding `AttrKeyMsid: "msid"` to a list of SDP attributes constants.

#### Reference issue
This would allow me to use the `AttrKeyMsid` constant instead of a literal `"msid"` string here: https://github.com/pion/webrtc/pull/1135