### PR TITLE
Safety codec name compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Luke S](https://github.com/encounter)
 * [Jerko Steiner](https://github.com/jeremija)
+* [Roman Romanenko](https://github.com/r-novel)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/util.go
+++ b/util.go
@@ -239,7 +239,7 @@ func equivalentFmtp(want, got string) bool {
 }
 
 func codecsMatch(wanted, got Codec) bool {
-	if wanted.Name != "" && wanted.Name != got.Name {
+	if wanted.Name != "" && !strings.EqualFold(wanted.Name, got.Name) {
 		return false
 	}
 	if wanted.ClockRate != 0 && wanted.ClockRate != got.ClockRate {


### PR DESCRIPTION
Added upper case for more safety comparing codec names

#### Description

Sometimes we should using GetPayloadTypeForCodec() for manually register codecs in mediaEngine;
For example:
```go
	parsed := pionSdp.SessionDescription{}
	if err := parsed.Unmarshal([]byte(p.OfferEncode())); err != nil {
		return fmt.Errorf("error unmarshal: %w", err)
	}

	opus := pionSdp.Codec{Name: "opus"}

	if payloadType, err := parsed.GetPayloadTypeForCodec(opus); err == nil  {
		me.RegisterCodec(webrtc.NewRTPOpusCodec(payloadType, 48000))
	}
```
In browser SDPs codec name may be in different case-styles. 

For example: 
Chrome almost always sent SDP with "opus" codec name in lower case, but pion-client sent SDP with "OPUS" in upper case. If we create Codec object with name in lower case-style (opus), and have got offer's codec name in upper case (OPUS) we could not determine payload type correctly.

My suggestion is to conversion 'got' and 'wanted' codec names to unified case-style for more safety.


