### PR TITLE
Media description fingerprints

### DIFF
--- a/jsep.go
+++ b/jsep.go
@@ -139,6 +139,11 @@ func (d *MediaDescription) WithValueAttribute(key, value string) *MediaDescripti
 	return d
 }
 
+// WithFingerprint adds a fingerprint to the media description
+func (d *MediaDescription) WithFingerprint(algorithm, value string) *MediaDescription {
+	return d.WithValueAttribute("fingerprint", algorithm+" "+value)
+}
+
 // WithICECredentials adds ICE credentials to the media description
 func (d *MediaDescription) WithICECredentials(username, password string) *MediaDescription {
 	return d.

--- a/media_description_test.go
+++ b/media_description_test.go
@@ -1,0 +1,20 @@
+package sdp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithFingerprint(t *testing.T) {
+	m := new(MediaDescription)
+
+	assert.Equal(t, []Attribute(nil), m.Attributes)
+
+	m = m.WithFingerprint("testalgorithm", "testfingerprint")
+
+	assert.Equal(t, []Attribute{
+		{"fingerprint", "testalgorithm testfingerprint"},
+	},
+		m.Attributes)
+}


### PR DESCRIPTION
This allows for more fine-grained control over dtls parameters. Some webrtc implementations want fingerprints to be specified this way. This PR will enable a "SDPMediaDescriptionFingerprint" configuration feature in pion/webrtc.