### PR TITLE
SDP unmarshaling 11% speedup

### DIFF
--- a/base_lexer.go
+++ b/base_lexer.go
@@ -1,0 +1,230 @@
+package sdp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+var errDocumentStart = errors.New("already on document start")
+
+type syntaxError struct {
+	s string
+	i int
+}
+
+func (e syntaxError) Error() string {
+	if e.i < 0 {
+		e.i = 0
+	}
+	head, middle, tail := e.s[:e.i], e.s[e.i:e.i+1], e.s[e.i+1:]
+	return fmt.Sprintf("%s --> %s <-- %s", head, middle, tail)
+}
+
+type baseLexer struct {
+	value []byte
+	pos   int
+}
+
+func (l baseLexer) syntaxError() error {
+	return syntaxError{s: string(l.value), i: l.pos - 1}
+}
+
+func (l *baseLexer) unreadByte() error {
+	if l.pos <= 0 {
+		return errDocumentStart
+	}
+	l.pos--
+	return nil
+}
+
+func (l *baseLexer) readByte() (byte, error) {
+	if l.pos >= len(l.value) {
+		return byte(0), io.EOF
+	}
+	ch := l.value[l.pos]
+	l.pos++
+	return ch, nil
+}
+
+func (l *baseLexer) nextLine() error {
+	for {
+		ch, err := l.readByte()
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if !isNewline(ch) {
+			return l.unreadByte()
+		}
+	}
+}
+
+func (l *baseLexer) readWhitespace() error {
+	for {
+		ch, err := l.readByte()
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if !isWhitespace(ch) {
+			return l.unreadByte()
+		}
+	}
+}
+
+func (l *baseLexer) readUint64Field() (i uint64, err error) {
+	for {
+		ch, err := l.readByte()
+		if err == io.EOF && i > 0 {
+			break
+		} else if err != nil {
+			return i, err
+		}
+
+		if isNewline(ch) {
+			if err := l.unreadByte(); err != nil {
+				return i, err
+			}
+			break
+		}
+
+		if isWhitespace(ch) {
+			if err := l.readWhitespace(); err != nil {
+				return i, err
+			}
+			break
+		}
+
+		switch ch {
+		case '0':
+			i *= 10
+		case '1':
+			i = i*10 + 1
+		case '2':
+			i = i*10 + 2
+		case '3':
+			i = i*10 + 3
+		case '4':
+			i = i*10 + 4
+		case '5':
+			i = i*10 + 5
+		case '6':
+			i = i*10 + 6
+		case '7':
+			i = i*10 + 7
+		case '8':
+			i = i*10 + 8
+		case '9':
+			i = i*10 + 9
+		default:
+			return i, l.syntaxError()
+		}
+	}
+
+	return i, nil
+}
+
+// Returns next field on this line or empty string if no more fields on line
+func (l *baseLexer) readField() (string, error) {
+	start := l.pos
+	stop := start
+	for {
+		stop = l.pos
+		ch, err := l.readByte()
+		if err == io.EOF && stop > start {
+			break
+		} else if err != nil {
+			return "", err
+		}
+
+		if isNewline(ch) {
+			if err := l.unreadByte(); err != nil {
+				return "", err
+			}
+			break
+		}
+
+		if isWhitespace(ch) {
+			if err := l.readWhitespace(); err != nil {
+				return "", err
+			}
+			break
+		}
+	}
+	return string(l.value[start:stop]), nil
+}
+
+// Returns symbols until line end
+func (l *baseLexer) readLine() (string, error) {
+	start := l.pos
+	trim := 1
+	for {
+		ch, err := l.readByte()
+		if err != nil {
+			return "", err
+		}
+		if ch == '\r' {
+			trim++
+		}
+		if ch == '\n' {
+			return string(l.value[start : l.pos-trim]), nil
+		}
+	}
+}
+
+func (l *baseLexer) readString(until byte) (string, error) {
+	start := l.pos
+	for {
+		ch, err := l.readByte()
+		if err != nil {
+			return "", err
+		}
+		if ch == until {
+			return string(l.value[start:l.pos]), nil
+		}
+	}
+}
+
+func (l *baseLexer) readType() (string, error) {
+	for {
+		b, err := l.readByte()
+		if err != nil {
+			return "", err
+		}
+
+		if isNewline(b) {
+			continue
+		}
+
+		if err := l.unreadByte(); err != nil {
+			return "", err
+		}
+
+		key, err := l.readString('=')
+		if err != nil {
+			return key, err
+		}
+
+		if len(key) == 2 {
+			return key, nil
+		}
+
+		return key, l.syntaxError()
+	}
+}
+
+func isNewline(ch byte) bool { return ch == '\n' || ch == '\r' }
+
+func isWhitespace(ch byte) bool { return ch == ' ' || ch == '\t' }
+
+func anyOf(element string, data ...string) bool {
+	for _, v := range data {
+		if element == v {
+			return true
+		}
+	}
+	return false
+}

--- a/base_lexer.go
+++ b/base_lexer.go
@@ -199,7 +199,8 @@ func (l *baseLexer) readType() (string, error) {
 			continue
 		}
 
-		if err := l.unreadByte(); err != nil {
+		err = l.unreadByte()
+		if err != nil {
 			return "", err
 		}
 

--- a/base_lexer_test.go
+++ b/base_lexer_test.go
@@ -1,17 +1,20 @@
 package sdp
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestLexer(t *testing.T) {
 	t.Run("single field", func(t *testing.T) {
-		for k, s := range map[string]string{
+		for k, value := range map[string]string{
 			"clean":            "aaa",
 			"with extra space": "aaa ",
 			"with linebreak":   "aaa \n",
 			"with linebreak 2": "aaa \r\n",
 		} {
 			t.Run(k, func(t *testing.T) {
-				l := &baseLexer{value: []byte(s)}
+				l := &baseLexer{value: []byte(value)}
 				field, err := l.readField()
 				if err != nil {
 					t.Fatal(err)
@@ -27,7 +30,7 @@ func TestLexer(t *testing.T) {
 		l := &baseLexer{value: []byte("12NaN")}
 		_, err := l.readUint64Field()
 		if err != nil {
-			err.Error() // smoke test
+			fmt.Println("error message:", err.Error())
 		} else {
 			t.Fatal("no error")
 		}

--- a/base_lexer_test.go
+++ b/base_lexer_test.go
@@ -13,16 +13,14 @@ func TestLexer(t *testing.T) {
 			"with linebreak":   "aaa \n",
 			"with linebreak 2": "aaa \r\n",
 		} {
-			t.Run(k, func(t *testing.T) {
-				l := &baseLexer{value: []byte(value)}
-				field, err := l.readField()
-				if err != nil {
-					t.Fatal(err)
-				}
-				if field != "aaa" {
-					t.Errorf("aaa not parsed, got: '%v'", field)
-				}
-			})
+			l := &baseLexer{value: []byte(value)}
+			field, err := l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "aaa" {
+				t.Errorf("%s: aaa not parsed, got: '%v'", k, field)
+			}
 		}
 	})
 

--- a/base_lexer_test.go
+++ b/base_lexer_test.go
@@ -1,0 +1,101 @@
+package sdp
+
+import "testing"
+
+func TestLexer(t *testing.T) {
+	t.Run("single field", func(t *testing.T) {
+		for k, s := range map[string]string{
+			"clean":            "aaa",
+			"with extra space": "aaa ",
+			"with linebreak":   "aaa \n",
+			"with linebreak 2": "aaa \r\n",
+		} {
+			t.Run(k, func(t *testing.T) {
+				l := &baseLexer{value: []byte(s)}
+				field, err := l.readField()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if field != "aaa" {
+					t.Errorf("aaa not parsed, got: '%v'", field)
+				}
+			})
+		}
+	})
+
+	t.Run("syntax error", func(t *testing.T) {
+		l := &baseLexer{value: []byte("12NaN")}
+		_, err := l.readUint64Field()
+		if err != nil {
+			err.Error() // smoke test
+		} else {
+			t.Fatal("no error")
+		}
+	})
+
+	t.Run("many fields", func(t *testing.T) {
+		l := &baseLexer{value: []byte("aaa  123\nf1 f2\nlast")}
+
+		t.Run("first line", func(t *testing.T) {
+			field, err := l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "aaa" {
+				t.Errorf("aaa not parsed, got: '%v'", field)
+			}
+
+			value, err := l.readUint64Field()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != 123 {
+				t.Errorf("aaa not parsed, got: '%v'", field)
+			}
+
+			if err := l.nextLine(); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("second line", func(t *testing.T) {
+			field, err := l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "f1" {
+				t.Errorf("value not parsed, got: '%v'", field)
+			}
+
+			field, err = l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "f2" {
+				t.Errorf("value not parsed, got: '%v'", field)
+			}
+
+			field, err = l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "" {
+				t.Errorf("value not parsed, got: '%v'", field)
+			}
+
+			if err := l.nextLine(); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("last line", func(t *testing.T) {
+			field, err := l.readField()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field != "last" {
+				t.Errorf("value not parsed, got: '%v'", field)
+			}
+		})
+	})
+}

--- a/common_description.go
+++ b/common_description.go
@@ -22,10 +22,9 @@ type ConnectionInformation struct {
 }
 
 func (c ConnectionInformation) String() string {
-	parts := []string{c.NetworkType, c.AddressType, c.Address.String()}
-	// Trim off Address if it is empty.
-	if parts[2] == "" {
-		parts = parts[:2]
+	parts := []string{c.NetworkType, c.AddressType}
+	if c.Address != nil && c.Address.String() != "" {
+		parts = append(parts, c.Address.String())
 	}
 	return strings.Join(parts, " ")
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -163,7 +163,7 @@ func TestMarshalCanonical(t *testing.T) {
 		t.Fatalf("Marshal(): err=%v, want %v", got, want)
 	}
 	if string(actual) != CanonicalMarshalSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", CanonicalMarshalSDP, actual)
+		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", CanonicalMarshalSDP, string(actual))
 	}
 }
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -1,8 +1,6 @@
 package sdp
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -97,10 +95,9 @@ func (s *SessionDescription) Unmarshal(value []byte) error {
 	if len(value) < bufsz {
 		bufsz = len(value)
 	}
-	l := &lexer{
-		desc:  s,
-		input: bufio.NewReaderSize(bytes.NewReader(value), bufsz),
-	}
+	l := new(lexer)
+	l.desc = s
+	l.value = value
 	for state := s1; state != nil; {
 		var err error
 		state, err = state(l)
@@ -112,7 +109,7 @@ func (s *SessionDescription) Unmarshal(value []byte) error {
 }
 
 func s1(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -125,7 +122,7 @@ func s1(l *lexer) (stateFn, error) {
 }
 
 func s2(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -138,7 +135,7 @@ func s2(l *lexer) (stateFn, error) {
 }
 
 func s3(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +148,7 @@ func s3(l *lexer) (stateFn, error) {
 }
 
 func s4(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -177,7 +174,7 @@ func s4(l *lexer) (stateFn, error) {
 }
 
 func s5(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +190,7 @@ func s5(l *lexer) (stateFn, error) {
 }
 
 func s6(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -213,7 +210,7 @@ func s6(l *lexer) (stateFn, error) {
 }
 
 func s7(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -237,7 +234,7 @@ func s7(l *lexer) (stateFn, error) {
 }
 
 func s8(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -255,7 +252,7 @@ func s8(l *lexer) (stateFn, error) {
 }
 
 func s9(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -282,7 +279,7 @@ func s9(l *lexer) (stateFn, error) {
 }
 
 func s10(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
 	}
@@ -304,7 +301,7 @@ func s10(l *lexer) (stateFn, error) {
 }
 
 func s11(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -323,7 +320,7 @@ func s11(l *lexer) (stateFn, error) {
 }
 
 func s12(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -350,7 +347,7 @@ func s12(l *lexer) (stateFn, error) {
 }
 
 func s13(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -371,7 +368,7 @@ func s13(l *lexer) (stateFn, error) {
 }
 
 func s14(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -402,7 +399,7 @@ func s14(l *lexer) (stateFn, error) {
 }
 
 func s15(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -430,7 +427,7 @@ func s15(l *lexer) (stateFn, error) {
 }
 
 func s16(l *lexer) (stateFn, error) {
-	key, err := readType(l.input)
+	key, err := l.readType()
 	if err != nil {
 		if err == io.EOF && key == "" {
 			return nil, nil
@@ -458,7 +455,7 @@ func s16(l *lexer) (stateFn, error) {
 }
 
 func unmarshalProtocolVersion(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +475,7 @@ func unmarshalProtocolVersion(l *lexer) (stateFn, error) {
 }
 
 func unmarshalOrigin(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -500,13 +497,13 @@ func unmarshalOrigin(l *lexer) (stateFn, error) {
 
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-8.2.6
-	if i := indexOf(fields[3], []string{"IN"}); i == -1 {
+	if !anyOf(fields[3], "IN") {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[3])
 	}
 
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-8.2.7
-	if i := indexOf(fields[4], []string{"IP4", "IP6"}); i == -1 {
+	if !anyOf(fields[4], "IP4", "IP6") {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[3])
 	}
 
@@ -523,7 +520,7 @@ func unmarshalOrigin(l *lexer) (stateFn, error) {
 }
 
 func unmarshalSessionName(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +530,7 @@ func unmarshalSessionName(l *lexer) (stateFn, error) {
 }
 
 func unmarshalSessionInformation(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +541,7 @@ func unmarshalSessionInformation(l *lexer) (stateFn, error) {
 }
 
 func unmarshalURI(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +555,7 @@ func unmarshalURI(l *lexer) (stateFn, error) {
 }
 
 func unmarshalEmail(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +566,7 @@ func unmarshalEmail(l *lexer) (stateFn, error) {
 }
 
 func unmarshalPhone(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -580,7 +577,7 @@ func unmarshalPhone(l *lexer) (stateFn, error) {
 }
 
 func unmarshalSessionConnectionInformation(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -600,13 +597,13 @@ func unmarshalConnectionInformation(value string) (*ConnectionInformation, error
 
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-8.2.6
-	if i := indexOf(fields[0], []string{"IN"}); i == -1 {
+	if !anyOf(fields[0], "IN") {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[0])
 	}
 
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-8.2.7
-	if i := indexOf(fields[1], []string{"IP4", "IP6"}); i == -1 {
+	if !anyOf(fields[1], "IP4", "IP6") {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[1])
 	}
 
@@ -623,7 +620,7 @@ func unmarshalConnectionInformation(value string) (*ConnectionInformation, error
 }
 
 func unmarshalSessionBandwidth(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +643,7 @@ func unmarshalBandwidth(value string) (*Bandwidth, error) {
 	experimental := strings.HasPrefix(parts[0], "X-")
 	if experimental {
 		parts[0] = strings.TrimPrefix(parts[0], "X-")
-	} else if i := indexOf(parts[0], []string{"CT", "AS"}); i == -1 {
+	} else if !anyOf(parts[0], "CT", "AS") {
 		// Set according to currently registered with IANA
 		// https://tools.ietf.org/html/rfc4566#section-5.8
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, parts[0])
@@ -665,7 +662,7 @@ func unmarshalBandwidth(value string) (*Bandwidth, error) {
 }
 
 func unmarshalTiming(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -693,7 +690,7 @@ func unmarshalTiming(l *lexer) (stateFn, error) {
 }
 
 func unmarshalRepeatTimes(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -729,7 +726,7 @@ func unmarshalRepeatTimes(l *lexer) (stateFn, error) {
 }
 
 func unmarshalTimeZones(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +759,7 @@ func unmarshalTimeZones(l *lexer) (stateFn, error) {
 }
 
 func unmarshalSessionEncryptionKey(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +770,7 @@ func unmarshalSessionEncryptionKey(l *lexer) (stateFn, error) {
 }
 
 func unmarshalSessionAttribute(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -791,7 +788,7 @@ func unmarshalSessionAttribute(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaDescription(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +803,7 @@ func unmarshalMediaDescription(l *lexer) (stateFn, error) {
 	// <media>
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-5.14
-	if i := indexOf(fields[0], []string{"audio", "video", "text", "application", "message"}); i == -1 {
+	if !anyOf(fields[0], "audio", "video", "text", "application", "message") {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[0])
 	}
 	newMediaDesc.MediaName.Media = fields[0]
@@ -830,7 +827,7 @@ func unmarshalMediaDescription(l *lexer) (stateFn, error) {
 	// Set according to currently registered with IANA
 	// https://tools.ietf.org/html/rfc4566#section-5.14
 	for _, proto := range strings.Split(fields[2], "/") {
-		if i := indexOf(proto, []string{"UDP", "RTP", "AVP", "SAVP", "SAVPF", "TLS", "DTLS", "SCTP", "AVPF"}); i == -1 {
+		if !anyOf(proto, "UDP", "RTP", "AVP", "SAVP", "SAVPF", "TLS", "DTLS", "SCTP", "AVPF") {
 			return nil, fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, fields[2])
 		}
 		newMediaDesc.MediaName.Protos = append(newMediaDesc.MediaName.Protos, proto)
@@ -847,7 +844,7 @@ func unmarshalMediaDescription(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaTitle(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +856,7 @@ func unmarshalMediaTitle(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaConnectionInformation(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +870,7 @@ func unmarshalMediaConnectionInformation(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaBandwidth(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -888,7 +885,7 @@ func unmarshalMediaBandwidth(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaEncryptionKey(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}
@@ -900,7 +897,7 @@ func unmarshalMediaEncryptionKey(l *lexer) (stateFn, error) {
 }
 
 func unmarshalMediaAttribute(l *lexer) (stateFn, error) {
-	value, err := readValue(l.input)
+	value, err := l.readLine()
 	if err != nil {
 		return nil, err
 	}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -91,10 +91,6 @@ var (
 // |   s16  |    |    14 |    |     |    |  15 |   |    | 12 |   |   |     |   |   |    |   |    |
 // +--------+----+-------+----+-----+----+-----+---+----+----+---+---+-----+---+---+----+---+----+
 func (s *SessionDescription) Unmarshal(value []byte) error {
-	bufsz := 4096
-	if len(value) < bufsz {
-		bufsz = len(value)
-	}
 	l := new(lexer)
 	l.desc = s
 	l.value = value

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -455,20 +455,19 @@ func s16(l *lexer) (stateFn, error) {
 }
 
 func unmarshalProtocolVersion(l *lexer) (stateFn, error) {
-	value, err := l.readLine()
+	version, err := l.readUint64Field()
 	if err != nil {
 		return nil, err
-	}
-
-	version, err := strconv.ParseInt(value, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, value)
 	}
 
 	// As off the latest draft of the rfc this value is required to be 0.
 	// https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-5.8.1
 	if version != 0 {
 		return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, version)
+	}
+
+	if err := l.nextLine(); err != nil {
+		return nil, err
 	}
 
 	return s2, nil

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -671,30 +671,24 @@ func unmarshalBandwidth(value string) (*Bandwidth, error) {
 }
 
 func unmarshalTiming(l *lexer) (stateFn, error) {
-	value, err := l.readLine()
+	var err error
+	var td TimeDescription
+
+	td.Timing.StartTime, err = l.readUint64Field()
 	if err != nil {
 		return nil, err
 	}
 
-	fields := strings.Fields(value)
-	if len(fields) < 2 {
-		return nil, fmt.Errorf("%w `t=%v`", errSDPInvalidSyntax, fields)
+	td.Timing.StopTime, err = l.readUint64Field()
+	if err != nil {
+		return nil, err
 	}
 
-	td := TimeDescription{}
-
-	td.Timing.StartTime, err = strconv.ParseUint(fields[0], 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, fields[1])
-	}
-
-	td.Timing.StopTime, err = strconv.ParseUint(fields[1], 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, fields[1])
+	if err := l.nextLine(); err != nil {
+		return nil, err
 	}
 
 	l.desc.TimeDescriptions = append(l.desc.TimeDescriptions, td)
-
 	return s9, nil
 }
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -837,7 +837,8 @@ func unmarshalMediaDescription(l *lexer) (stateFn, error) {
 	}
 
 	if len(parts) > 1 {
-		portRange, err := strconv.Atoi(parts[1])
+		var portRange int
+		portRange, err = strconv.Atoi(parts[1])
 		if err != nil {
 			return nil, fmt.Errorf("%w `%v`", errSDPInvalidValue, parts)
 		}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -3,7 +3,6 @@ package sdp
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -105,349 +104,264 @@ func (s *SessionDescription) Unmarshal(value []byte) error {
 }
 
 func s1(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	if key == "v=" {
-		return unmarshalProtocolVersion, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		if key == "v=" {
+			return unmarshalProtocolVersion
+		}
+		return nil
+	})
 }
 
 func s2(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	if key == "o=" {
-		return unmarshalOrigin, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		if key == "o=" {
+			return unmarshalOrigin
+		}
+		return nil
+	})
 }
 
 func s3(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, err
-	}
-
-	if key == "s=" {
-		return unmarshalSessionName, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		if key == "s=" {
+			return unmarshalSessionName
+		}
+		return nil
+	})
 }
 
 func s4(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	switch key {
-	case "i=":
-		return unmarshalSessionInformation, nil
-	case "u=":
-		return unmarshalURI, nil
-	case "e=":
-		return unmarshalEmail, nil
-	case "p=":
-		return unmarshalPhone, nil
-	case "c=":
-		return unmarshalSessionConnectionInformation, nil
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "i=":
+			return unmarshalSessionInformation
+		case "u=":
+			return unmarshalURI
+		case "e=":
+			return unmarshalEmail
+		case "p=":
+			return unmarshalPhone
+		case "c=":
+			return unmarshalSessionConnectionInformation
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s5(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, err
-	}
-
-	switch key {
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s6(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	switch key {
-	case "p=":
-		return unmarshalPhone, nil
-	case "c=":
-		return unmarshalSessionConnectionInformation, nil
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "p=":
+			return unmarshalPhone
+		case "c=":
+			return unmarshalSessionConnectionInformation
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s7(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	switch key {
-	case "u=":
-		return unmarshalURI, nil
-	case "e=":
-		return unmarshalEmail, nil
-	case "p=":
-		return unmarshalPhone, nil
-	case "c=":
-		return unmarshalSessionConnectionInformation, nil
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "u=":
+			return unmarshalURI
+		case "e=":
+			return unmarshalEmail
+		case "p=":
+			return unmarshalPhone
+		case "c=":
+			return unmarshalSessionConnectionInformation
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s8(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	switch key {
-	case "c=":
-		return unmarshalSessionConnectionInformation, nil
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "c=":
+			return unmarshalSessionConnectionInformation
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s9(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "z=":
+			return unmarshalTimeZones
+		case "k=":
+			return unmarshalSessionEncryptionKey
+		case "a=":
+			return unmarshalSessionAttribute
+		case "r=":
+			return unmarshalRepeatTimes
+		case "t=":
+			return unmarshalTiming
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "z=":
-		return unmarshalTimeZones, nil
-	case "k=":
-		return unmarshalSessionEncryptionKey, nil
-	case "a=":
-		return unmarshalSessionAttribute, nil
-	case "r=":
-		return unmarshalRepeatTimes, nil
-	case "t=":
-		return unmarshalTiming, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s10(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
-	}
-
-	switch key {
-	case "e=":
-		return unmarshalEmail, nil
-	case "p=":
-		return unmarshalPhone, nil
-	case "c=":
-		return unmarshalSessionConnectionInformation, nil
-	case "b=":
-		return unmarshalSessionBandwidth, nil
-	case "t=":
-		return unmarshalTiming, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "e=":
+			return unmarshalEmail
+		case "p=":
+			return unmarshalPhone
+		case "c=":
+			return unmarshalSessionConnectionInformation
+		case "b=":
+			return unmarshalSessionBandwidth
+		case "t=":
+			return unmarshalTiming
+		}
+		return nil
+	})
 }
 
 func s11(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalSessionAttribute
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalSessionAttribute, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s12(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalMediaAttribute
+		case "k=":
+			return unmarshalMediaEncryptionKey
+		case "b=":
+			return unmarshalMediaBandwidth
+		case "c=":
+			return unmarshalMediaConnectionInformation
+		case "i=":
+			return unmarshalMediaTitle
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalMediaAttribute, nil
-	case "k=":
-		return unmarshalMediaEncryptionKey, nil
-	case "b=":
-		return unmarshalMediaBandwidth, nil
-	case "c=":
-		return unmarshalMediaConnectionInformation, nil
-	case "i=":
-		return unmarshalMediaTitle, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s13(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalSessionAttribute
+		case "k=":
+			return unmarshalSessionEncryptionKey
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalSessionAttribute, nil
-	case "k=":
-		return unmarshalSessionEncryptionKey, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s14(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalMediaAttribute
+		case "k=":
+			// Non-spec ordering
+			return unmarshalMediaEncryptionKey
+		case "b=":
+			// Non-spec ordering
+			return unmarshalMediaBandwidth
+		case "c=":
+			// Non-spec ordering
+			return unmarshalMediaConnectionInformation
+		case "i=":
+			// Non-spec ordering
+			return unmarshalMediaTitle
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalMediaAttribute, nil
-	case "k=":
-		// Non-spec ordering
-		return unmarshalMediaEncryptionKey, nil
-	case "b=":
-		// Non-spec ordering
-		return unmarshalMediaBandwidth, nil
-	case "c=":
-		// Non-spec ordering
-		return unmarshalMediaConnectionInformation, nil
-	case "i=":
-		// Non-spec ordering
-		return unmarshalMediaTitle, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s15(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalMediaAttribute
+		case "k=":
+			return unmarshalMediaEncryptionKey
+		case "b=":
+			return unmarshalMediaBandwidth
+		case "c=":
+			return unmarshalMediaConnectionInformation
+		case "i=":
+			// Non-spec ordering
+			return unmarshalMediaTitle
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalMediaAttribute, nil
-	case "k=":
-		return unmarshalMediaEncryptionKey, nil
-	case "b=":
-		return unmarshalMediaBandwidth, nil
-	case "c=":
-		return unmarshalMediaConnectionInformation, nil
-	case "i=":
-		// Non-spec ordering
-		return unmarshalMediaTitle, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func s16(l *lexer) (stateFn, error) {
-	key, err := l.readType()
-	if err != nil {
-		if err == io.EOF && key == "" {
-			return nil, nil
+	return l.handleType(func(key string) stateFn {
+		switch key {
+		case "a=":
+			return unmarshalMediaAttribute
+		case "k=":
+			return unmarshalMediaEncryptionKey
+		case "c=":
+			return unmarshalMediaConnectionInformation
+		case "b=":
+			return unmarshalMediaBandwidth
+		case "i=":
+			// Non-spec ordering
+			return unmarshalMediaTitle
+		case "m=":
+			return unmarshalMediaDescription
 		}
-		return nil, err
-	}
-
-	switch key {
-	case "a=":
-		return unmarshalMediaAttribute, nil
-	case "k=":
-		return unmarshalMediaEncryptionKey, nil
-	case "c=":
-		return unmarshalMediaConnectionInformation, nil
-	case "b=":
-		return unmarshalMediaBandwidth, nil
-	case "i=":
-		// Non-spec ordering
-		return unmarshalMediaTitle, nil
-	case "m=":
-		return unmarshalMediaDescription, nil
-	}
-
-	return nil, fmt.Errorf("%w `%v`", errSDPInvalidSyntax, key)
+		return nil
+	})
 }
 
 func unmarshalProtocolVersion(l *lexer) (stateFn, error) {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -329,7 +329,7 @@ func TestUnmarshalRepeatTimes(t *testing.T) {
 		t.Fatalf("Marshal(): err=%v, want %v", got, want)
 	}
 	if string(actual) != RepeatTimesSDPExpected {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", RepeatTimesSDPExpected, actual)
+		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", RepeatTimesSDPExpected, string(actual))
 	}
 }
 
@@ -344,7 +344,7 @@ func TestUnmarshalTimeZones(t *testing.T) {
 		t.Fatalf("Marshal(): err=%v, want %v", got, want)
 	}
 	if string(actual) != TimeZonesSDPExpected {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", TimeZonesSDPExpected, actual)
+		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", TimeZonesSDPExpected, string(actual))
 	}
 }
 
@@ -365,6 +365,7 @@ func TestUnmarshalNonNilAddress(t *testing.T) {
 }
 
 func BenchmarkUnmarshal(b *testing.B) {
+	b.ReportAllocs()
 	raw := []byte(CanonicalUnmarshalSDP)
 	for i := 0; i < b.N; i++ {
 		var sd SessionDescription

--- a/util.go
+++ b/util.go
@@ -1,10 +1,8 @@
 package sdp
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -295,58 +293,8 @@ func (s *SessionDescription) GetPayloadTypeForCodec(wanted Codec) (uint8, error)
 }
 
 type lexer struct {
-	desc  *SessionDescription
-	input *bufio.Reader
+	desc *SessionDescription
+	baseLexer
 }
 
 type stateFn func(*lexer) (stateFn, error)
-
-func readType(input *bufio.Reader) (string, error) {
-	for {
-		b, err := input.ReadByte()
-		if err != nil {
-			return "", err
-		}
-		if b == '\n' || b == '\r' {
-			continue
-		}
-		if err = input.UnreadByte(); err != nil {
-			return "", err
-		}
-
-		key, err := input.ReadString('=')
-		if err != nil {
-			return key, err
-		}
-
-		switch len(key) {
-		case 2:
-			return key, nil
-		default:
-			return key, fmt.Errorf("%w: %v", errSyntaxError, strconv.Quote(key))
-		}
-	}
-}
-
-func readValue(input *bufio.Reader) (string, error) {
-	lineBytes, _, err := input.ReadLine()
-	line := string(lineBytes)
-	if err != nil && err != io.EOF {
-		return line, err
-	}
-
-	if len(line) == 0 {
-		return line, io.EOF
-	}
-
-	return line, nil
-}
-
-func indexOf(element string, data []string) int {
-	for k, v := range data {
-		if element == v {
-			return k
-		}
-	}
-	return -1
-}


### PR DESCRIPTION
#### Description

- strings.Fields() and strconv.ParseInt() replaced by new functions: lexer.readField() and lexer.readUint64Field()
- because sdp size is small, lexer now uses just simple []byte
- new parseError show invalid position
- bug in tests messages: bytes wasn't converted to strings before output
- bug in ConnectionInformation.String(): nil pointer dereference

#### Benchmarks (before/after)
BenchmarkUnmarshal-12    	  156142	      6981 ns/op	    4008 B/op	     108 allocs/op
BenchmarkUnmarshal-12    	  167923	      6193 ns/op	    2584 B/op	     108 allocs/op

