### PR TITLE
extmap: Add ssrc-audio-level RTP extension URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [ZHENK](https://github.com/scorpionknifes)
 * [Tarrence van As](https://github.com/tarrencev)
 * [Maxim Oransky](https://github.com/sdfsdhgjkbmnmxc)
+* [Graham King](https://github.com/grahamking/)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/extmap.go
+++ b/extmap.go
@@ -18,6 +18,7 @@ const (
 	TransportCCURI     = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
 	SDESMidURI         = "urn:ietf:params:rtp-hdrext:sdes:mid"
 	SDESRTPStreamIDURI = "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+	AudioLevelURI      = "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
 )
 
 // ExtMap represents the activation of a single RTP header extension


### PR DESCRIPTION
This is for ion-sfu to be able to register this RTP extension. From RFC6464.
