### PR TITLE
Fix incorrect conversion between integer types

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
 Brendan Abolivier <babolivier@matrix.org>
 chenkaiC4 <chenkaic4@gmail.com>
+Daniele Sluijters <daenney@users.noreply.github.com>
 Graham King <graham@gkgk.org>
 Guilherme <gqgs@protonmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>

--- a/util.go
+++ b/util.go
@@ -98,7 +98,7 @@ func parseRtpmap(rtpmap string) (Codec, error) {
 		return codec, parsingFailed
 	}
 
-	ptInt, err := strconv.Atoi(ptSplit[1])
+	ptInt, err := strconv.ParseUint(ptSplit[1], 10, 8)
 	if err != nil {
 		return codec, parsingFailed
 	}
@@ -109,7 +109,7 @@ func parseRtpmap(rtpmap string) (Codec, error) {
 	codec.Name = split[0]
 	parts := len(split)
 	if parts > 1 {
-		rate, err := strconv.Atoi(split[1])
+		rate, err := strconv.ParseUint(split[1], 10, 32)
 		if err != nil {
 			return codec, parsingFailed
 		}
@@ -139,7 +139,7 @@ func parseFmtp(fmtp string) (Codec, error) {
 		return codec, parsingFailed
 	}
 
-	ptInt, err := strconv.Atoi(split[1])
+	ptInt, err := strconv.ParseUint(split[1], 10, 8)
 	if err != nil {
 		return codec, parsingFailed
 	}
@@ -165,7 +165,7 @@ func parseRtcpFb(rtcpFb string) (Codec, error) {
 		return codec, parsingFailed
 	}
 
-	ptInt, err := strconv.Atoi(ptSplit[1])
+	ptInt, err := strconv.ParseUint(ptSplit[1], 10, 8)
 	if err != nil {
 		return codec, parsingFailed
 	}


### PR DESCRIPTION
The result of strconv.Atoi uses an architecture dependent bit size. It
is not safe to use when converted to an integer type of a smaller size,
without performing bounds checking.

Instead, use Parse(U)int with the desired base and size. Though this
returns a (u)int64, it can then be safely converted into a (u)int8 etc.

Same deal as pion/webrtc#2208.