### PR TITLE
Cleanup lexer syntax errors

### DIFF
--- a/base_lexer.go
+++ b/base_lexer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 var errDocumentStart = errors.New("already on document start")
@@ -17,8 +18,7 @@ func (e syntaxError) Error() string {
 	if e.i < 0 {
 		e.i = 0
 	}
-	head, middle, tail := e.s[:e.i], e.s[e.i:e.i+1], e.s[e.i+1:]
-	return fmt.Sprintf("%s --> %s <-- %s", head, middle, tail)
+	return fmt.Sprintf("sdp: syntax error at pos %d: %s", e.i, strconv.QuoteToASCII(e.s[e.i:e.i+1]))
 }
 
 type baseLexer struct {


### PR DESCRIPTION
#### Description

This shortens SDP lexer errors to a single line like: `syntax error: at pos 50: "="`.

Currently SDP lexer errors are formatted with the whole SDP echoed and a cursor like `==>` `<==` around the where the lexer found an unexpected character. These errors are difficult to log and difficult to detect as invalid SDPs. 

#### Reference issue
Fixes #140 
