### PR TITLE
Fix GetCodecForPayloadType() with Alexa WebRTC

### DIFF
--- a/util.go
+++ b/util.go
@@ -203,7 +203,19 @@ func mergeCodecs(codec Codec, codecs map[uint8]Codec) {
 }
 
 func (s *SessionDescription) buildCodecMap() map[uint8]Codec {
-	codecs := make(map[uint8]Codec)
+	codecs := map[uint8]Codec{
+		// static codecs that do not require a rtpmap
+		0: {
+			PayloadType: 0,
+			Name:        "PCMU",
+			ClockRate:   8000,
+		},
+		8: {
+			PayloadType: 8,
+			Name:        "PCMA",
+			ClockRate:   8000,
+		},
+	}
 
 	for _, m := range s.MediaDescriptions {
 		for _, a := range m.Attributes {


### PR DESCRIPTION
#### Description

WebRTC offers from Alexa do not include the rtpmap attribute for payload types 0 and 8, and this makes GetCodecForPayloadType() return a fatal error. The current SDP specification (RFC8866) explicitly tells that rtpmap is not mandatory in case of these static payload types:

> consider u-law PCM encoded single-channel audio sampled at 8 kHz. This is completely defined in the RTP audio/video profile as payload type 0, so there is no need for an "a=rtpmap:" attribute

This patch fixes the issue.

#### Reference issue

https://github.com/bluenviron/mediamtx/discussions/2539