### PR TITLE
Optimize Marshal

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// nolint: goconst
 const (
 	CanonicalMarshalSDP = "v=0\r\n" +
 		"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +
@@ -37,6 +38,7 @@ const (
 		"a=rtpmap:99 h263-1998/90000\r\n"
 )
 
+// nolint: goconst
 func TestMarshalCanonical(t *testing.T) {
 	sd := &SessionDescription{
 		Version: 0,

--- a/media_description.go
+++ b/media_description.go
@@ -5,7 +5,6 @@ package sdp
 
 import (
 	"strconv"
-	"strings"
 )
 
 // MediaDescription represents a media type.
@@ -65,6 +64,15 @@ func (p *RangedPort) String() string {
 	return output
 }
 
+func (p RangedPort) marshalInto(b []byte) []byte {
+	b = strconv.AppendInt(b, int64(p.Value), 10)
+	if p.Range != nil {
+		b = append(b, '/')
+		b = strconv.AppendInt(b, int64(*p.Range), 10)
+	}
+	return b
+}
+
 func (p RangedPort) marshalSize() (size int) {
 	size = lenInt(int64(p.Value))
 	if p.Range != nil {
@@ -83,34 +91,38 @@ type MediaName struct {
 }
 
 func (m MediaName) String() string {
-	return strings.Join([]string{
-		m.Media,
-		m.Port.String(),
-		strings.Join(m.Protos, "/"),
-		strings.Join(m.Formats, " "),
-	}, " ")
+	return stringFromMarshal(m.marshalInto, m.marshalSize)
+}
+
+func (m MediaName) marshalInto(b []byte) []byte {
+	appendList := func(list []string, sep byte) {
+		for i, p := range list {
+			if i != 0 && i != len(list) {
+				b = append(b, sep)
+			}
+			b = append(b, p...)
+		}
+	}
+
+	b = append(append(b, m.Media...), ' ')
+	b = append(m.Port.marshalInto(b), ' ')
+	appendList(m.Protos, '/')
+	b = append(b, ' ')
+	appendList(m.Formats, ' ')
+	return b
 }
 
 func (m MediaName) marshalSize() (size int) {
+	listSize := func(list []string) {
+		for _, p := range list {
+			size += 1 + len(p)
+		}
+	}
+
 	size = len(m.Media)
-
 	size += 1 + m.Port.marshalSize()
-
-	for i, p := range m.Protos {
-		if i != len(m.Protos) {
-			size++
-		}
-
-		size += len(p)
-	}
-
-	for i, f := range m.Formats {
-		if i != len(m.Formats) {
-			size++
-		}
-
-		size += len(f)
-	}
+	listSize(m.Protos)
+	listSize(m.Formats)
 
 	return size
 }

--- a/media_description.go
+++ b/media_description.go
@@ -65,6 +65,15 @@ func (p *RangedPort) String() string {
 	return output
 }
 
+func (p RangedPort) marshalSize() (size int) {
+	size = lenInt(int64(p.Value))
+	if p.Range != nil {
+		size += 1 + lenInt(int64(*p.Range))
+	}
+
+	return
+}
+
 // MediaName describes the "m=" field storage structure.
 type MediaName struct {
 	Media   string
@@ -80,4 +89,28 @@ func (m MediaName) String() string {
 		strings.Join(m.Protos, "/"),
 		strings.Join(m.Formats, " "),
 	}, " ")
+}
+
+func (m MediaName) marshalSize() (size int) {
+	size = len(m.Media)
+
+	size += 1 + m.Port.marshalSize()
+
+	for i, p := range m.Protos {
+		if i != len(m.Protos) {
+			size++
+		}
+
+		size += len(p)
+	}
+
+	for i, f := range m.Formats {
+		if i != len(m.Formats) {
+			size++
+		}
+
+		size += len(f)
+	}
+
+	return size
 }

--- a/session_description.go
+++ b/session_description.go
@@ -4,7 +4,6 @@
 package sdp
 
 import (
-	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -85,7 +84,11 @@ func (s *SessionDescription) Attribute(key string) (string, bool) {
 type Version int
 
 func (v Version) String() string {
-	return strconv.Itoa(int(v))
+	return stringFromMarshal(v.marshalInto, v.marshalSize)
+}
+
+func (v Version) marshalInto(b []byte) []byte {
+	return strconv.AppendInt(b, int64(v), 10)
 }
 
 func (v Version) marshalSize() (size int) {
@@ -104,15 +107,16 @@ type Origin struct {
 }
 
 func (o Origin) String() string {
-	return fmt.Sprintf(
-		"%v %d %d %v %v %v",
-		o.Username,
-		o.SessionID,
-		o.SessionVersion,
-		o.NetworkType,
-		o.AddressType,
-		o.UnicastAddress,
-	)
+	return stringFromMarshal(o.marshalInto, o.marshalSize)
+}
+
+func (o Origin) marshalInto(b []byte) []byte {
+	b = append(append(b, o.Username...), ' ')
+	b = append(strconv.AppendUint(b, o.SessionID, 10), ' ')
+	b = append(strconv.AppendUint(b, o.SessionVersion, 10), ' ')
+	b = append(append(b, o.NetworkType...), ' ')
+	b = append(append(b, o.AddressType...), ' ')
+	return append(b, o.UnicastAddress...)
 }
 
 func (o Origin) marshalSize() (size int) {
@@ -130,7 +134,11 @@ func (o Origin) marshalSize() (size int) {
 type SessionName string
 
 func (s SessionName) String() string {
-	return string(s)
+	return stringFromMarshal(s.marshalInto, s.marshalSize)
+}
+
+func (s SessionName) marshalInto(b []byte) []byte {
+	return append(b, s...)
 }
 
 func (s SessionName) marshalSize() (size int) {
@@ -143,7 +151,11 @@ func (s SessionName) marshalSize() (size int) {
 type EmailAddress string
 
 func (e EmailAddress) String() string {
-	return string(e)
+	return stringFromMarshal(e.marshalInto, e.marshalSize)
+}
+
+func (e EmailAddress) marshalInto(b []byte) []byte {
+	return append(b, e...)
 }
 
 func (e EmailAddress) marshalSize() (size int) {
@@ -156,7 +168,11 @@ func (e EmailAddress) marshalSize() (size int) {
 type PhoneNumber string
 
 func (p PhoneNumber) String() string {
-	return string(p)
+	return stringFromMarshal(p.marshalInto, p.marshalSize)
+}
+
+func (p PhoneNumber) marshalInto(b []byte) []byte {
+	return append(b, p...)
 }
 
 func (p PhoneNumber) marshalSize() (size int) {
@@ -171,7 +187,13 @@ type TimeZone struct {
 }
 
 func (z TimeZone) String() string {
-	return strconv.FormatUint(z.AdjustmentTime, 10) + " " + strconv.FormatInt(z.Offset, 10)
+	return stringFromMarshal(z.marshalInto, z.marshalSize)
+}
+
+func (z TimeZone) marshalInto(b []byte) []byte {
+	b = strconv.AppendUint(b, z.AdjustmentTime, 10)
+	b = append(b, ' ')
+	return strconv.AppendInt(b, z.Offset, 10)
 }
 
 func (z TimeZone) marshalSize() (size int) {

--- a/session_description.go
+++ b/session_description.go
@@ -88,6 +88,10 @@ func (v Version) String() string {
 	return strconv.Itoa(int(v))
 }
 
+func (v Version) marshalSize() (size int) {
+	return lenInt(int64(v))
+}
+
 // Origin defines the structure for the "o=" field which provides the
 // originator of the session plus a session identifier and version number.
 type Origin struct {
@@ -111,12 +115,26 @@ func (o Origin) String() string {
 	)
 }
 
+func (o Origin) marshalSize() (size int) {
+	return len(o.Username) +
+		lenUint(o.SessionID) +
+		lenUint(o.SessionVersion) +
+		len(o.NetworkType) +
+		len(o.AddressType) +
+		len(o.UnicastAddress) +
+		5
+}
+
 // SessionName describes a structured representations for the "s=" field
 // and is the textual session name.
 type SessionName string
 
 func (s SessionName) String() string {
 	return string(s)
+}
+
+func (s SessionName) marshalSize() (size int) {
+	return len(s)
 }
 
 // EmailAddress describes a structured representations for the "e=" line
@@ -128,6 +146,10 @@ func (e EmailAddress) String() string {
 	return string(e)
 }
 
+func (e EmailAddress) marshalSize() (size int) {
+	return len(e)
+}
+
 // PhoneNumber describes a structured representations for the "p=" line
 // specify phone contact information for the person responsible for the
 // conference.
@@ -135,6 +157,10 @@ type PhoneNumber string
 
 func (p PhoneNumber) String() string {
 	return string(p)
+}
+
+func (p PhoneNumber) marshalSize() (size int) {
+	return len(p)
 }
 
 // TimeZone defines the structured object for "z=" line which describes
@@ -146,4 +172,8 @@ type TimeZone struct {
 
 func (z TimeZone) String() string {
 	return strconv.FormatUint(z.AdjustmentTime, 10) + " " + strconv.FormatInt(z.Offset, 10)
+}
+
+func (z TimeZone) marshalSize() (size int) {
+	return lenUint(z.AdjustmentTime) + 1 + lenInt(z.Offset)
 }

--- a/time_description.go
+++ b/time_description.go
@@ -34,6 +34,10 @@ func (t Timing) String() string {
 	return output
 }
 
+func (t Timing) marshalSize() (size int) {
+	return lenUint(t.StartTime) + 1 + lenUint(t.StopTime)
+}
+
 // RepeatTime describes the "r=" fields of the session description which
 // represents the intervals and durations for repeated scheduled sessions.
 type RepeatTime struct {
@@ -51,4 +55,14 @@ func (r RepeatTime) String() string {
 	}
 
 	return strings.Join(fields, " ")
+}
+
+func (r RepeatTime) marshalSize() (size int) {
+	size = lenInt(r.Interval)
+	size += 1 + lenInt(r.Duration)
+	for _, o := range r.Offsets {
+		size += 1 + lenInt(o)
+	}
+
+	return
 }

--- a/time_description.go
+++ b/time_description.go
@@ -5,7 +5,6 @@ package sdp
 
 import (
 	"strconv"
-	"strings"
 )
 
 // TimeDescription describes "t=", "r=" fields of the session description
@@ -29,9 +28,12 @@ type Timing struct {
 }
 
 func (t Timing) String() string {
-	output := strconv.FormatUint(t.StartTime, 10)
-	output += " " + strconv.FormatUint(t.StopTime, 10)
-	return output
+	return stringFromMarshal(t.marshalInto, t.marshalSize)
+}
+
+func (t Timing) marshalInto(b []byte) []byte {
+	b = append(strconv.AppendUint(b, t.StartTime, 10), ' ')
+	return strconv.AppendUint(b, t.StopTime, 10)
 }
 
 func (t Timing) marshalSize() (size int) {
@@ -47,14 +49,19 @@ type RepeatTime struct {
 }
 
 func (r RepeatTime) String() string {
-	fields := make([]string, 0)
-	fields = append(fields, strconv.FormatInt(r.Interval, 10))
-	fields = append(fields, strconv.FormatInt(r.Duration, 10))
+	return stringFromMarshal(r.marshalInto, r.marshalSize)
+}
+
+func (r RepeatTime) marshalInto(b []byte) []byte {
+	b = strconv.AppendInt(b, r.Interval, 10)
+	b = append(b, ' ')
+	b = strconv.AppendInt(b, r.Duration, 10)
 	for _, value := range r.Offsets {
-		fields = append(fields, strconv.FormatInt(value, 10))
+		b = append(b, ' ')
+		b = strconv.AppendInt(b, value, 10)
 	}
 
-	return strings.Join(fields, " ")
+	return b
 }
 
 func (r RepeatTime) marshalSize() (size int) {


### PR DESCRIPTION
    This reduces the amount of allocations need to marshal a SessionDescription

    Before
    '''
    BenchmarkMarshal-8        227802              5000 ns/op            2064 B/op         53 allocs/op
    BenchmarkMarshal-8        226938              5050 ns/op            2064 B/op         53 allocs/op
    BenchmarkMarshal-8        230073              5033 ns/op            2064 B/op         53 allocs/op
    BenchmarkMarshal-8        230949              5009 ns/op            2064 B/op         53 allocs/op
    BenchmarkMarshal-8        229460              4991 ns/op            2064 B/op         53 allocs/op
    '''

    After
    '''
    BenchmarkMarshal-8        460330              2237 ns/op             800 B/op          7 allocs/op
    BenchmarkMarshal-8        464844              2273 ns/op             800 B/op          7 allocs/op
    BenchmarkMarshal-8        475477              2271 ns/op             800 B/op          7 allocs/op
    BenchmarkMarshal-8        482371              2285 ns/op             800 B/op          7 allocs/op
    BenchmarkMarshal-8        479281              2265 ns/op             800 B/op          7 allocs/op
    '''
