### PR TITLE
Update lint rules, force testify/assert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/base_lexer_test.go
+++ b/base_lexer_test.go
@@ -20,7 +20,7 @@ func TestLexer(t *testing.T) {
 			l := &baseLexer{value: value}
 			field, err := l.readField()
 			assert.NoError(t, err)
-			assert.Equalf(t, field, "aaa", "%s: aaa not parsed, got: '%v'", k, field)
+			assert.Equalf(t, "aaa", field, "%s: aaa not parsed, got: '%v'", k, field)
 		}
 	})
 
@@ -36,7 +36,7 @@ func TestLexer(t *testing.T) {
 		t.Run("first line", func(t *testing.T) {
 			field, err := lex.readField()
 			assert.NoError(t, err)
-			assert.Equal(t, field, "aaa")
+			assert.Equal(t, "aaa", field)
 
 			value, err := lex.readUint64Field()
 			assert.NoError(t, err)
@@ -48,15 +48,15 @@ func TestLexer(t *testing.T) {
 		t.Run("second line", func(t *testing.T) {
 			field, err := lex.readField()
 			assert.NoError(t, err)
-			assert.Equal(t, field, "f1")
+			assert.Equal(t, "f1", field)
 
 			field, err = lex.readField()
 			assert.NoError(t, err)
-			assert.Equal(t, field, "f2")
+			assert.Equal(t, "f2", field)
 
 			field, err = lex.readField()
 			assert.NoError(t, err)
-			assert.Equal(t, field, "")
+			assert.Empty(t, field)
 
 			assert.NoError(t, lex.nextLine())
 		})
@@ -64,7 +64,7 @@ func TestLexer(t *testing.T) {
 		t.Run("last line", func(t *testing.T) {
 			field, err := lex.readField()
 			assert.NoError(t, err)
-			assert.Equal(t, field, "last")
+			assert.Equal(t, "last", field)
 		})
 	})
 }

--- a/extmap_test.go
+++ b/extmap_test.go
@@ -47,6 +47,9 @@ func TestTransportCCExtMap(t *testing.T) {
 		URI:   uri,
 	}
 
-	assert.NotEqual(t, e.Marshal(),
-		"3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01")
+	assert.NotEqual(
+		t, "3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+		e.Marshal(),
+		"TestTransportCC failed",
+	)
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -362,9 +362,7 @@ func TestUnmarshalRepeatTimes(t *testing.T) {
 	assert.Equal(t, RepeatTimesSDPExpected, string(actual))
 
 	err = sd.UnmarshalString(TimingSDP + "r=\r\n")
-	if !assert.ErrorIs(t, err, errSDPInvalidValue) {
-		assert.NoError(t, err)
-	}
+	assert.ErrorIs(t, err, errSDPInvalidValue)
 }
 
 func TestUnmarshalTimeZones(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -261,7 +261,7 @@ func TestCodecMultipleValues(t *testing.T) {
 			)
 
 			_, err := sd.GetPayloadTypeForCodec(Codec{Name: "VP8/90000"})
-			assert.ErrorIs(t, test.expectedError, err)
+			assert.ErrorIs(t, err, test.expectedError)
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Use testify's assert instead of the standard library's testing helpers.

#### Reference

https://github.com/pion/sdp/pull/200
https://github.com/pion/.goassets/pull/222