### PR TITLE
Remove ic2 from ice-options

### DIFF
--- a/jsep.go
+++ b/jsep.go
@@ -117,9 +117,7 @@ func (s *SessionDescription) WithValueAttribute(key, value string) *SessionDescr
 // WithICETrickleAdvertised advertises ICE trickle support in the session description.
 // See https://datatracker.ietf.org/doc/html/rfc9429#section-5.2.1
 func (s *SessionDescription) WithICETrickleAdvertised() *SessionDescription {
-	s.WithValueAttribute(AttrKeyICEOptions, "trickle ice2")
-
-	return s
+	return s.WithValueAttribute(AttrKeyICEOptions, "trickle")
 }
 
 // WithFingerprint adds a fingerprint to the session description.

--- a/jsep_test.go
+++ b/jsep_test.go
@@ -56,7 +56,7 @@ func TestSessionDescriptionAttributes(t *testing.T) {
 		sd = sd.WithICETrickleAdvertised()
 		assert.Len(t, sd.Attributes, 3)
 		assert.Equal(t, AttrKeyICEOptions, sd.Attributes[2].Key)
-		assert.Equal(t, "trickle ice2", sd.Attributes[2].Value)
+		assert.Equal(t, "trickle", sd.Attributes[2].Value)
 	})
 
 	t.Run("WithFingerprint", func(t *testing.T) {


### PR DESCRIPTION
#### Description

Remove ic2 from ice-options

#### Reference issue

> I think the general idea is right here. But do NOT put ice2 into the ice-options here. Pion doesn't support ice2 yet. That is whole different big project.
> For this issue and PR we should only add a=ice-options:trickle.

https://github.com/pion/webrtc/pull/3097