### PR TITLE
Added attribute cryptex

### DIFF
--- a/jsep.go
+++ b/jsep.go
@@ -32,6 +32,7 @@ const (
 	AttrKeySendRecv         = "sendrecv"
 	AttrKeyExtMap           = "extmap"
 	AttrKeyExtMapAllowMixed = "extmap-allow-mixed"
+	AttrKeyCryptex          = "cryptex"
 )
 
 // Constants for semantic tokens used in JSEP.


### PR DESCRIPTION
This attribute is used to negotiate encryption of RTP Header Extensions and Contributing Sources as specified in RFC 9335.
