### PR TITLE
Accept any <proto> value

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -873,34 +873,7 @@ func unmarshalMediaDescription(lex *lexer) (stateFn, error) { //nolint:cyclop
 	if err != nil {
 		return nil, err
 	}
-
-	// Set according to currently registered with IANA
-	// https://tools.ietf.org/html/rfc4566#section-5.14
-	// https://tools.ietf.org/html/rfc4975#section-8.1
-	for _, proto := range strings.Split(field, "/") {
-		if !anyOf(
-			proto,
-			"UDP",
-			"RTP",
-			"AVP",
-			"SAVP",
-			"SAVPF",
-			"TLS",
-			"DTLS",
-			"SCTP",
-			"AVPF",
-			"TCP",
-			"MSRP",
-			"BFCP",
-			"UDT",
-			"IX",
-			"MRCPv2",
-			"FEC",
-		) {
-			return nil, fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, field)
-		}
-		newMediaDesc.MediaName.Protos = append(newMediaDesc.MediaName.Protos, proto)
-	}
+	newMediaDesc.MediaName.Protos = strings.Split(field, "/")
 
 	// <fmt>...
 	for {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1812,19 +1812,6 @@ func TestUnmarshalMediaDescription_SetsPortRange(t *testing.T) {
 	}
 }
 
-func TestUnmarshalMediaDescription_Error_InvalidProto(t *testing.T) {
-	// proto token not in the allowed list
-	l := &lexer{
-		desc:      &SessionDescription{},
-		cache:     &unmarshalCache{},
-		baseLexer: baseLexer{value: "audio 9 WRONG/PROTO 0\r\n"},
-	}
-
-	st, err := unmarshalMediaDescription(l)
-	assert.Nil(t, st)
-	assert.ErrorIs(t, err, errSDPInvalidNumericValue)
-}
-
 func TestUnmarshalMediaTitle_Error_ReadLine(t *testing.T) {
 	// empty input
 	l := &lexer{


### PR DESCRIPTION
#### Description

This makes the parser accept any proto value similar to how we handle fmt.

The latest spec (rfc-8866) doesn't explicitly address unknown proto values but https://github.com/pion/sdp/pull/242 got me thinking that this parser will break every-time a new value is added to IANA.

We can't log a warning either because we don't pass pion/logging to SDP (I think we should when we introduce a new construction API to sdp).

Also this is us being more: be liberal in what you accept from others.